### PR TITLE
[experimental] Simplify positioning logic

### DIFF
--- a/src/ThisContainers.tsx
+++ b/src/ThisContainers.tsx
@@ -1,0 +1,56 @@
+import React, { forwardRef } from 'react';
+
+import { ReactCompareSliderCommonProps } from './types';
+
+/** Internal container for clipped item. */
+export const ThisClipContainer = forwardRef<
+  HTMLDivElement,
+  React.HTMLProps<HTMLDivElement>
+>((props, ref): React.ReactElement => {
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    willChange: 'clip-path',
+    userSelect: 'none',
+    KhtmlUserSelect: 'none',
+    MozUserSelect: 'none',
+    WebkitUserSelect: 'none',
+  };
+
+  return <div {...props} style={style} data-rcs="clip-item" ref={ref} />;
+});
+
+ThisClipContainer.displayName = 'ThisClipContainer';
+
+/** Internal handle container to control position. */
+export const ThisHandleContainer = forwardRef<
+  HTMLDivElement,
+  React.HTMLProps<HTMLDivElement> & Pick<ReactCompareSliderCommonProps, 'portrait'>
+>(({ children, portrait }, ref): React.ReactElement => {
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    width: '100%',
+    height: '100%',
+    pointerEvents: 'none',
+  };
+
+  const innerStyle: React.CSSProperties = {
+    position: 'absolute',
+    width: portrait ? '100%' : undefined,
+    height: portrait ? undefined : '100%',
+    transform: portrait ? 'translateY(-50%)' : 'translateX(-50%)',
+    pointerEvents: 'all',
+  };
+
+  return (
+    <div style={style} data-rcs="handle-container" ref={ref}>
+      <div style={innerStyle}>{children}</div>
+    </div>
+  );
+});
+
+ThisHandleContainer.displayName = 'ThisHandleContainer';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,32 +74,3 @@ export const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' && window.document && window.document.createElement
     ? useLayoutEffect
     : useEffect;
-
-/** Params passed to `useResizeObserver` `handler` function. */
-export type UseResizeObserverHandlerParams = DOMRect;
-
-/**
- * Bind resize observer callback to element.
- * @param ref       - Element to bind to.
- * @param handler   - Callback for handling entry's bounding rect.
- */
-export const useResizeObserver = (
-  ref: RefObject<Element>,
-  handler: (entry: UseResizeObserverHandlerParams) => void
-): void => {
-  const observer = useRef<ResizeObserver>();
-
-  const observe = useCallback(() => {
-    if (ref.current && observer.current) observer.current.observe(ref.current);
-  }, [ref]);
-
-  // Bind/rebind observer when `handler` changes.
-  useIsomorphicLayoutEffect(() => {
-    observer.current = new ResizeObserver(([entry]) => handler(entry.contentRect));
-    observe();
-
-    return (): void => {
-      if (observer.current) observer.current.disconnect();
-    };
-  }, [handler, observe]);
-};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "include": ["src", "types"],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
     "rootDir": "./src",
+    "removeComments": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
- [x] Use CSS `clip-path` instead of `clip` so percentages can be used to maintain position without using `ResizeObserver`
- [ ] Use `PointerEvent` instead of individual mouse and touch events
- [ ] Improve bounds checking to avoid issues with `0` and `100` values on mount
- [ ] Compare with latest release on Safari, Firefox and Chrome
	- [ ] Ensure touch is at least as smooth as current 
- [x] ~~Try [tsup](https://github.com/egoist/tsup) in place of tsdx~~ - build is only a little faster
- [ ] Use Playwright for tests
