### PR TITLE
feat: add support for CSS `transform: scale()`

### DIFF
--- a/src/ReactCompareSlider.tsx
+++ b/src/ReactCompareSlider.tsx
@@ -297,13 +297,18 @@ export const ReactCompareSlider: React.FC<
   }, []);
 
   /** Resync internal position on resize. */
-  const handleResize = useCallback(
-    ({ width, height }: UseResizeObserverHandlerParams) => {
+  const handleResize = useCallback<(arg0: UseResizeObserverHandlerParams) => void>(
+    ({ width, height }) => {
+      const {
+        width: scaledWidth,
+        height: scaledHeight,
+      } = (rootContainerRef.current as HTMLDivElement).getBoundingClientRect();
+
       updateInternalPosition({
         portrait,
         boundsPadding,
-        x: (width / 100) * internalPositionPc.current,
-        y: (height / 100) * internalPositionPc.current,
+        x: ((width / 100) * internalPositionPc.current * scaledWidth) / width,
+        y: ((height / 100) * internalPositionPc.current * scaledHeight) / height,
       });
     },
     [portrait, boundsPadding, updateInternalPosition]

--- a/src/ReactCompareSlider.tsx
+++ b/src/ReactCompareSlider.tsx
@@ -70,6 +70,8 @@ export interface ReactCompareSliderProps extends Partial<ReactCompareSliderCommo
   boundsPadding?: number;
   /** Whether the slider should follow the pointer on hover. */
   changePositionOnHover?: boolean;
+  /** Corrects the handle position if the image is zoomed/scaled. */
+  zoomScale?: number;
   /** Custom handle component. */
   handle?: React.ReactNode;
   /** First item to show. */
@@ -109,6 +111,7 @@ export const ReactCompareSlider: React.FC<
   position = 50,
   boundsPadding = 0,
   changePositionOnHover = false,
+  zoomScale = 1,
   style,
   ...props
 }): React.ReactElement => {
@@ -258,13 +261,13 @@ export const ReactCompareSlider: React.FC<
         portrait,
         boundsPadding,
         isOffset: true,
-        x: ev instanceof MouseEvent ? ev.pageX : ev.touches[0].pageX,
-        y: ev instanceof MouseEvent ? ev.pageY : ev.touches[0].pageY,
+        x: ev instanceof MouseEvent ? ev.pageX / zoomScale : ev.touches[0].pageX / zoomScale,
+        y: ev instanceof MouseEvent ? ev.pageY / zoomScale : ev.touches[0].pageY / zoomScale,
       });
 
       setIsDragging(true);
     },
-    [portrait, boundsPadding, updateInternalPosition]
+    [portrait, boundsPadding, updateInternalPosition, zoomScale]
   );
 
   /** Handle mouse/touch move. */
@@ -274,11 +277,11 @@ export const ReactCompareSlider: React.FC<
         portrait,
         boundsPadding,
         isOffset: true,
-        x: ev instanceof MouseEvent ? ev.pageX : ev.touches[0].pageX,
-        y: ev instanceof MouseEvent ? ev.pageY : ev.touches[0].pageY,
+        x: ev instanceof MouseEvent ? ev.pageX / zoomScale : ev.touches[0].pageX / zoomScale,
+        y: ev instanceof MouseEvent ? ev.pageY / zoomScale : ev.touches[0].pageY / zoomScale,
       });
     },
-    [portrait, boundsPadding, updateInternalPosition]
+    [portrait, boundsPadding, updateInternalPosition, zoomScale]
   );
 
   /** Handle mouse/touch up. */


### PR DESCRIPTION
I have a problem where if a parent element is zoomed/scaled, it causes the slider position to be off-sync with the mouse.

Example:
```ts
<div className="container" style={{transform: "scale(0.5)"}}>
  <ReactCompareSlider
    changePositionOnHover={true}
    itemOne={<img src={oldImage} className="image"/>}
    itemTwo={<img src={newImage} className="image"/>}
  />
</div>
```

The solution is to factor in this zoomScale as follows:
```ts
const adjustedPos = positionPx / _zoomScale;
const adjustedWidth = width / _zoomScale;
const adjustedHeight = height / _zoomScale;
```
When it is set to `1` (the default) the calculations will be unchanged, but if the zoomScale is set to `0.5` the position change should be faster as you are zoomed out, and if it is set to `2` the position change will be slower since you are zoomed in.

Now with the following code the slider would remain in sync with the mouse:
```ts
<div className="container" style={{transform: "scale(0.5)"}}>
  <ReactCompareSlider
    changePositionOnHover={true}
    zoomScale={0.5}
    itemOne={<img src={oldImage} className="image"/>}
    itemTwo={<img src={newImage} className="image"/>}
  />
</div>
```