### PR TITLE
Use custom browsing context instead of global window object if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ export const Example = () => {
 | [`portrait`](https://react-compare-slider.vercel.app/?path=/story/demos--portrait)                                  | `boolean`   |              | `false`       | Whether to use portrait orientation.                                                                  |
 | [`position`](https://react-compare-slider.vercel.app/?path=/story/demos--position)                                  | `number`    |              | `50`          | Initial percentage position of divide (`0-100`).                                                      |
 | [`transition`](https://react-compare-slider.vercel.app/?path=/story/demos--transition)                                  | `string`    |              | `undefined`          | Shorthand CSS `transition` property to apply to handle movement. E.g. `.5s ease-in-out`                                                      |
+| [`browsingContext`](https://react-compare-slider.vercel.app/?path=/story/demos--browsing-context) | `Window` | | `undefined` | Custom browsing context to use instead of the global `window` object when listening for pointer events. |
 
 [API docs](https://react-compare-slider.vercel.app/?path=/docs/docs-api--docs) for more information.
 

--- a/lib/src/ReactCompareSlider.tsx
+++ b/lib/src/ReactCompareSlider.tsx
@@ -48,6 +48,7 @@ export const ReactCompareSlider = forwardRef<
       keyboardIncrement = '5%',
       style,
       transition,
+      browsingContext = window,
       ...props
     },
     ref,
@@ -64,8 +65,8 @@ export const ReactCompareSlider = forwardRef<
     const [isDragging, setIsDragging] = useState(false);
     /** Whether the `transition` property can be applied. */
     const [canTransition, setCanTransition] = useState(true);
-    /** Whether component has a `window` event binding. */
-    const hasWindowBinding = useRef(false);
+    /** Whether component has a `browsingContext` event binding. */
+    const hasBrowsingContextBinding = useRef(false);
     /** Target container for pointer events. */
     const [interactiveTarget, setInteractiveTarget] = useState<HTMLElement | null>();
     /** The `position` value at *previous* render. */
@@ -86,10 +87,10 @@ export const ReactCompareSlider = forwardRef<
 
         const pixelPosition = portrait
           ? isOffset
-            ? y - top - window.scrollY
+            ? y - top - browsingContext.scrollY
             : y
           : isOffset
-          ? x - left - window.scrollX
+          ? x - left - browsingContext.scrollX
           : x;
 
         /** Next position as percentage. */
@@ -268,17 +269,17 @@ export const ReactCompareSlider = forwardRef<
 
     // Allow drag outside of container while pointer is still down.
     useEffect(() => {
-      if (isDragging && !hasWindowBinding.current) {
-        window.addEventListener('pointermove', handlePointerMove, EVENT_PASSIVE_PARAMS);
-        window.addEventListener('pointerup', handlePointerUp, EVENT_PASSIVE_PARAMS);
-        hasWindowBinding.current = true;
+      if (isDragging && !hasBrowsingContextBinding.current) {
+        browsingContext.addEventListener('pointermove', handlePointerMove, EVENT_PASSIVE_PARAMS);
+        browsingContext.addEventListener('pointerup', handlePointerUp, EVENT_PASSIVE_PARAMS);
+        hasBrowsingContextBinding.current = true;
       }
 
       return (): void => {
-        if (hasWindowBinding.current) {
-          window.removeEventListener('pointermove', handlePointerMove);
-          window.removeEventListener('pointerup', handlePointerUp);
-          hasWindowBinding.current = false;
+        if (hasBrowsingContextBinding.current) {
+          browsingContext.removeEventListener('pointermove', handlePointerMove);
+          browsingContext.removeEventListener('pointerup', handlePointerUp);
+          hasBrowsingContextBinding.current = false;
         }
       };
     }, [handlePointerMove, handlePointerUp, isDragging]);

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -37,6 +37,8 @@ export interface ReactCompareSliderRootProps extends Partial<ReactCompareSliderC
   onlyHandleDraggable?: boolean;
   /** Callback on position change with position as percentage. */
   onPositionChange?: (position: ReactCompareSliderPropPosition) => void;
+  /** Custom browsing context to use instead of the global `window` object. */
+  browsingContext?: Window;
 }
 
 /** Properties returned by the `useReactCompareSliderRef` hook. */


### PR DESCRIPTION
I ran into a scenario where I needed to use this library in a popup window and the easiest solution was to render the component using a React portal. The issue then was that this library was listening for events on the "origin" window object instead of the popup window.

If we allow users to pass in a custom browsing context as a prop it's fairly easy to solve this issue. Here's a trivial example with some sudo-ish code to illustrate the solution.

```javascript
const browsingContext = window.open("", "", "popup");

return createPortal(
    <ReactCompareSlider browsingContext={browsingContext} ...>
        ...
    </ReactCompareSlider>,
    browsingContext.document.body
);
```

I couldn't for the life of me get the storybook to run locally without any errors so I didn't create any additional documentation, examples or tests. Since this solution falls back to the global `window` object if no browsing context is provided this doesn't break anything.

If you need any additional explanation of examples please let me know.